### PR TITLE
Refactor API endpoint paths to remove redundant '/api' prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ ALLOWED_API_KEYS=key1,key2,key3
 
   - Returns a simple status check to verify the server is running
 
-- **Claude API Proxy**: `POST /api/v1/messages`
+- **Claude API Proxy**: `POST /v1/messages`
   - Forwards requests to the Claude API's `/v1/messages` endpoint
   - Streaming is disabled by default (no need to set `stream: false`)
   - Preserves necessary headers (Authorization, x-api-key, anthropic-version, anthropic-beta)
@@ -159,7 +159,7 @@ PRXY_URL=http://localhost:3000
 You can also use cURL to test the proxy server:
 
 ```bash
-curl -X POST http://localhost:3000/api/v1/messages \
+curl -X POST http://localhost:3000/v1/messages \
   -H "Content-Type: application/json" \
   -H "x-api-key: your_claude_api_key_here" \
   -H "anthropic-version: 2023-06-01" \
@@ -179,7 +179,7 @@ curl -X POST http://localhost:3000/api/v1/messages \
 Note that `stream: false` is the default behavior. For streaming responses, explicitly set `stream: true`:
 
 ```bash
-curl -X POST http://localhost:3000/api/v1/messages \
+curl -X POST http://localhost:3000/v1/messages \
   -H "Content-Type: application/json" \
   -H "x-api-key: your_claude_api_key_here" \
   -H "anthropic-version: 2023-06-01" \

--- a/clients/go/client.go
+++ b/clients/go/client.go
@@ -152,7 +152,7 @@ func sendRequest(request ClaudeRequest, proxyURL string, apiKey string, bold, cy
 	fmt.Println()
 
 	// Create a new HTTP request
-	req, err := http.NewRequest("POST", proxyURL+"/api/v1/messages", bytes.NewBuffer(requestBody))
+	req, err := http.NewRequest("POST", proxyURL+"/v1/messages", bytes.NewBuffer(requestBody))
 	if err != nil {
 		fmt.Printf("%s: %v\n", yellow("Error creating request"), err)
 		os.Exit(1)

--- a/clients/ts/index.ts
+++ b/clients/ts/index.ts
@@ -23,7 +23,7 @@ export function createClaudeProxyClient(config: ClaudeClientConfig): Anthropic {
   // Create Anthropic client with custom baseURL pointing to our proxy
   const client = new Anthropic({
     apiKey,
-    baseURL: `${config.prxyUrl}/api`,
+    baseURL: config.prxyUrl,
   });
 
   return client;

--- a/main.go
+++ b/main.go
@@ -66,7 +66,7 @@ func main() {
 	})).Methods("GET")
 
 	// Claude API proxy endpoint
-	r.HandleFunc("/api/v1/messages", loggingMiddleware(claudeProxyHandler)).Methods("POST")
+	r.HandleFunc("/v1/messages", loggingMiddleware(claudeProxyHandler)).Methods("POST")
 
 	// Set up CORS
 	c := cors.New(cors.Options{


### PR DESCRIPTION
Refactor API endpoint paths to remove redundant '/api' prefix for Claude API proxy. Update related documentation and client configurations accordingly.