### PR TITLE
Add configurable EC2 instance type to Pulumi infrastructure (#8)

### DIFF
--- a/infra/index.ts
+++ b/infra/index.ts
@@ -5,6 +5,7 @@ import * as awsx from "@pulumi/awsx";
 // Get configuration
 const config = new pulumi.Config();
 const projectName = config.get("PROJECT_NAME") || "prxy";
+const ec2InstanceType = config.get("EC2_INSTANCE_TYPE") || "t2.micro";
 const ecrRepoUrl = config.require("ECR_REPO_URL");
 const s3Bucket = config.require("S3_BUCKET");
 const imageTag = config.get("IMAGE_TAG") || "latest";
@@ -223,7 +224,7 @@ const instance = new aws.ec2.Instance("prxy-ec2-instance", {
       { name: "virtualization-type", values: ["hvm"] },
     ],
   }).id,
-  instanceType: "t2.micro",
+  instanceType: ec2InstanceType,
   subnetId: vpc.publicSubnetIds[0],
   vpcSecurityGroupIds: [securityGroup.id],
   iamInstanceProfile: instanceProfile.name,


### PR DESCRIPTION
- Introduced a new configuration option for EC2 instance type, defaulting to "t2.micro".
- Updated the EC2 instance creation logic to use the configurable instance type instead of a hardcoded value.