### PR TITLE
Add Elastic IP allocation for EC2 instance and update README

### DIFF
--- a/infra/README.md
+++ b/infra/README.md
@@ -15,6 +15,7 @@ The deployment process:
 
 - **VPC**: Dedicated VPC for the PRXY server
 - **EC2 Instance**: t2.micro instance running the PRXY container
+- **Elastic IP**: Static IP address assigned to the EC2 instance
 - **Security Group**: Allows traffic on port 3000 (PRXY) and port 22 (SSH) from any IP address
 - **IAM Role**: Provides the EC2 instance with permissions to pull from ECR and access S3
 

--- a/infra/index.ts
+++ b/infra/index.ts
@@ -245,8 +245,18 @@ const instance = new aws.ec2.Instance("prxy-ec2-instance", {
   },
 });
 
+// Create an Elastic IP for the instance
+const elasticIp = new aws.ec2.Eip("prxy-eip", {
+  vpc: true,
+  instance: instance.id,
+  tags: {
+    Name: "prxy-eip",
+    Project: projectName,
+  },
+});
+
 // Export the public IP of the instance
-export const publicIp = instance.publicIp;
-export const endpoint = pulumi.interpolate`http://${instance.publicIp}:3000`;
+export const publicIp = elasticIp.publicIp;
+export const endpoint = pulumi.interpolate`http://${elasticIp.publicIp}:3000`;
 export const deployedImageTag = imageTag;
 export const deployedAt = deploymentTimestamp.toString();


### PR DESCRIPTION
- Created an Elastic IP resource for the EC2 instance to provide a static IP address.
- Updated the public IP export to reference the new Elastic IP.
- Revised the README to include information about the newly added Elastic IP feature, enhancing documentation clarity.