### PR TITLE
Update AWS deployment workflow and infrastructure configuration

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,4 +1,4 @@
-name: Deploy PRXY to AWS
+name: Deploy to AWS
 
 on:
   push:
@@ -7,7 +7,9 @@ on:
 
 env:
   AWS_REGION: us-east-1
+  PROJECT_NAME: prxy
   ECR_REPOSITORY: prxy
+  EC2_INSTANCE_TYPE: t3.micro
 
 jobs:
   build-and-push:
@@ -104,7 +106,9 @@ jobs:
           pulumi stack select dev --create
 
           # Set configs
+          pulumi config set PROJECT_NAME ${{ env.PROJECT_NAME }}
           pulumi config set aws:region ${{ env.AWS_REGION }}
+          pulumi config set EC2_INSTANCE_TYPE ${{ env.EC2_INSTANCE_TYPE }}
           pulumi config set ECR_REPO_URL "$ECR_REPO_URL"
           pulumi config set S3_BUCKET ${{ secrets.S3_BUCKET }}
           pulumi config set IMAGE_TAG ${{ github.sha }}
@@ -143,7 +147,7 @@ jobs:
         run: |
           # Get instance ID from Pulumi output
           cd ./infra
-          INSTANCE_ID=$(aws ec2 describe-instances --filters "Name=tag:Project,Values=PRXY" --query "Reservations[*].Instances[*].InstanceId" --output text)
+          INSTANCE_ID=$(aws ec2 describe-instances --filters "Name=tag:Name,Values=${{ env.PROJECT_NAME }}" --query "Reservations[*].Instances[*].InstanceId" --output text)
 
           if [ -n "$INSTANCE_ID" ]; then
             echo "Found EC2 instance: $INSTANCE_ID, triggering update..."

--- a/infra/index.ts
+++ b/infra/index.ts
@@ -116,8 +116,6 @@ const instanceProfile = new aws.iam.InstanceProfile("prxy-instance-profile", {
 
 // User data script to install Docker and run the container
 const userData = pulumi.interpolate`#!/bin/bash
-# Deployment timestamp: ${deploymentTimestamp}
-
 # Install Docker
 sudo apt-get update
 sudo apt-get install -y docker.io awscli
@@ -227,7 +225,7 @@ const instance = new aws.ec2.Instance("prxy-ec2-instance", {
     filters: [
       {
         name: "name",
-        values: ["ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-*"],
+        values: ["ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-*"],
       },
       { name: "virtualization-type", values: ["hvm"] },
     ],
@@ -238,7 +236,7 @@ const instance = new aws.ec2.Instance("prxy-ec2-instance", {
   iamInstanceProfile: instanceProfile.name,
   userData: userData,
   tags: {
-    Name: "prxy",
+    Name: projectName,
     ImageTag: imageTag,
     DeployedAt: deploymentTimestamp.toString(),
     Project: projectName,


### PR DESCRIPTION
- Renamed the deployment workflow to "Deploy to AWS" for clarity.
- Added new environment variables for project name and EC2 instance type in the GitHub Actions workflow.
- Updated Pulumi configuration to set the project name and EC2 instance type dynamically.
- Modified EC2 instance filtering to use the project name tag instead of a hardcoded value.
- Changed the base image for the EC2 instance from Ubuntu 20.04 to 22.04 for improved compatibility and support.