### PR TITLE
Refactor AWS deployment workflow and update README for SSH access

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -151,28 +151,11 @@ jobs:
           if [ -n "$INSTANCE_ID" ]; then
             echo "Found EC2 instance: $INSTANCE_ID, triggering update..."
             
-            # Try SSM first (if permissions allow)
-            set +e
-            aws ssm send-command \
-              --instance-ids "$INSTANCE_ID" \
-              --document-name "AWS-RunShellScript" \
-              --parameters commands="/home/ubuntu/prxy/update.sh ${{ secrets.S3_BUCKET }} ${{ needs.build-and-push.outputs.repo-url }} ${{ github.sha }}" \
-              --comment "Update PRXY container" 2>/dev/null
-
-            SSM_EXIT_CODE=$?
-            set -e
-
-            if [ $SSM_EXIT_CODE -eq 0 ]; then
-              echo "Update command sent via SSM. Container will be updated shortly."
-            else
-              echo "SSM command failed, falling back to S3 trigger method..."
-              
-              # Alternative: Create a trigger file in S3 that the EC2 instance will poll for
-              echo "${{ needs.build-and-push.outputs.repo-url }}:${{ github.sha }}" > update-trigger.txt
-              aws s3 cp update-trigger.txt s3://${{ secrets.S3_BUCKET }}/update-trigger.txt
-              
-              echo "Created update trigger in S3 bucket. Instance will pull updates on next cron cycle."
-            fi
+            # Create a trigger file in S3 that the EC2 instance will poll for
+            echo "${{ needs.build-and-push.outputs.repo-url }}:${{ github.sha }}" > update-trigger.txt
+            aws s3 cp update-trigger.txt s3://${{ secrets.S3_BUCKET }}/update-trigger.txt
+            
+            echo "Created update trigger in S3 bucket. Instance will pull updates on next cron cycle."
           else
             echo "EC2 instance not found. It may be creating for the first time."
           fi

--- a/infra/README.md
+++ b/infra/README.md
@@ -19,29 +19,6 @@ The deployment process:
 - **Security Group**: Allows traffic on port 3000 (PRXY) and port 22 (SSH) from any IP address
 - **IAM Role**: Provides the EC2 instance with permissions to pull from ECR and access S3
 
-## SSH Access
-
-The EC2 instance allows SSH access from any IP address. You can connect using standard SSH methods:
-
-```bash
-ssh -i your-key-pair.pem ubuntu@<EC2-Public-IP>
-```
-
-You can also use EC2 Instance Connect through the AWS Console or AWS CLI for convenience:
-
-1. Through the AWS Console:
-
-   - Go to the EC2 service
-   - Select the instance
-   - Click "Connect" button
-   - Choose "EC2 Instance Connect" tab
-   - Click "Connect" button
-
-2. Using the AWS CLI:
-   ```bash
-   aws ec2-instance-connect ssh --instance-id i-01234567890abcdef --os-user ubuntu
-   ```
-
 ## GitHub Actions Workflow
 
 The GitHub Actions workflow automates the entire deployment process:
@@ -109,3 +86,75 @@ http://<EC2-Public-IP>:3000
 ```
 
 The public IP address is output at the end of the Pulumi deployment.
+
+## SSH Access
+
+### Connecting to the EC2 Instance
+
+The EC2 instance allows SSH access from any IP address. You can connect using standard SSH methods:
+
+```bash
+ssh -i your-key-pair.pem ubuntu@<EC2-Public-IP>
+```
+
+You can also use EC2 Instance Connect through the AWS Console or AWS CLI for convenience:
+
+1. Through the AWS Console:
+
+   - Go to the EC2 service
+   - Select the instance
+   - Click "Connect" button
+   - Choose "EC2 Instance Connect" tab
+   - Click "Connect" button
+
+2. Using the AWS CLI:
+
+   ```bash
+   aws ec2-instance-connect ssh --instance-id i-01234567890abcdef --os-user ubuntu
+   ```
+
+### Docker Container Management
+
+Once connected to the instance via SSH, you can manage the Docker container:
+
+1. List running containers:
+
+   ```bash
+   docker ps
+   ```
+
+2. List all containers (including stopped ones):
+
+   ```bash
+   docker ps -a
+   ```
+
+3. View container logs:
+
+   ```bash
+   docker logs prxy
+   ```
+
+4. Follow container logs in real-time:
+
+   ```bash
+   docker logs -f prxy
+   ```
+
+5. Restart the container:
+
+   ```bash
+   docker restart prxy
+   ```
+
+6. View container details:
+
+   ```bash
+   docker inspect prxy
+   ```
+
+7. Check update logs:
+
+   ```bash
+   cat /home/ubuntu/prxy/update.log
+   ```

--- a/infra/index.ts
+++ b/infra/index.ts
@@ -100,12 +100,6 @@ const s3Policy = new aws.iam.RolePolicyAttachment("prxy-s3-policy", {
   policyArn: "arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess",
 });
 
-// Attach policy for SSM access
-const ssmPolicy = new aws.iam.RolePolicyAttachment("prxy-ssm-policy", {
-  role: ec2Role.name,
-  policyArn: "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore",
-});
-
 // Create an instance profile
 const instanceProfile = new aws.iam.InstanceProfile("prxy-instance-profile", {
   role: ec2Role.name,


### PR DESCRIPTION
- Simplified the GitHub Actions workflow by removing the SSM command fallback and directly creating an S3 trigger for EC2 instance updates.
- Removed unnecessary SSM policy attachment from the infrastructure code.
- Enhanced the README to include detailed instructions for SSH access and Docker container management, improving user guidance.