### PR TITLE
Update Dockerfile to copy only main.go for optimized build context

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ COPY go.mod go.sum* ./
 RUN go mod download
 
 # Copy the source code
-COPY . .
+COPY main.go ./
 
 # Build the application with optimizations
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags="-w -s" -o /app/prxy


### PR DESCRIPTION
- Modified the Dockerfile to copy only the main.go file instead of the entire source code, streamlining the build context and potentially reducing image size.