### PR TITLE
Refactor S3 policy attachment

### DIFF
--- a/infra/index.ts
+++ b/infra/index.ts
@@ -95,9 +95,18 @@ const ecrPolicy = new aws.iam.RolePolicy("prxy-ecr-inline-policy", {
 });
 
 // Attach policies for S3 access
-const s3Policy = new aws.iam.RolePolicyAttachment("prxy-s3-policy", {
-  role: ec2Role.name,
-  policyArn: "arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess",
+const s3Policy = new aws.iam.RolePolicy("prxy-s3-policy", {
+  role: ec2Role.id,
+  policy: JSON.stringify({
+    Version: "2012-10-17",
+    Statement: [
+      {
+        Effect: "Allow",
+        Action: ["s3:GetObject", "s3:ListBucket", "s3:DeleteObject"],
+        Resource: [`arn:aws:s3:::${s3Bucket}`, `arn:aws:s3:::${s3Bucket}/*`],
+      },
+    ],
+  }),
 });
 
 // Create an instance profile


### PR DESCRIPTION
- Changed the S3 policy from a role policy attachment to an inline role policy, allowing for more granular control over permissions.
- Updated the policy to include actions for GetObject, ListBucket, and DeleteObject, ensuring comprehensive access to the specified S3 bucket.