### PR TITLE
Update Claude API request handling to clarify stream parameter logic

### DIFF
--- a/main.go
+++ b/main.go
@@ -309,9 +309,8 @@ func claudeProxyHandler(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	// For the Claude API, we need to ensure stream parameter matches what the client requested
+	// For non-streaming requests, ensure stream is set to false
 	if !streamRequested {
-		// For non-streaming requests, ensure stream is set to false
 		requestData["stream"] = false
 	}
 


### PR DESCRIPTION
- Revised comment in the claudeProxyHandler function to specify that the stream parameter should be set to false for non-streaming requests, enhancing code clarity.